### PR TITLE
Fix compiler errors

### DIFF
--- a/src/Model.cpp
+++ b/src/Model.cpp
@@ -19,10 +19,10 @@ void Model::addPyramid(
     points.push_back(p3);
     points.push_back(p4);
 
-    triangles.push_back({si + 0, si + 1, si + 2});
-    triangles.push_back({si + 0, si + 1, si + 3});
-    triangles.push_back({si + 0, si + 2, si + 3});
-    triangles.push_back({si + 1, si + 2, si + 3});
+    triangles.push_back(std::make_tuple(si + 0, si + 1, si + 2));
+    triangles.push_back(std::make_tuple(si + 0, si + 1, si + 3));
+    triangles.push_back(std::make_tuple(si + 0, si + 2, si + 3));
+    triangles.push_back(std::make_tuple(si + 1, si + 2, si + 3));
 
     colors.push_back(c1);
     colors.push_back(c2);


### PR DESCRIPTION
We get the following errors without this fix:

```
/home/valera/github.com/r0mai/3d-fractals/src/Model.cpp: In member function ‘void fractals::Model::addPyramid(const vec3&, const vec3&, const vec3&, const vec3&, const fractals::Color&, const fractals::Color&, const fractals::Color&, const fractals::Color&)’:
/home/valera/github.com/r0mai/3d-fractals/src/Model.cpp:22:49: error: converting to ‘std::vector<std::tuple<long unsigned int, long unsigned int, long unsigned int> >::value_type {aka std::tuple<long unsigned int, long unsigned int, long unsigned int>}’ from initializer list would use explicit constructor ‘constexpr std::tuple< <template-parameter-1-1> >::tuple(_UElements&& ...) [with _UElements = {long unsigned int, long unsigned int, long unsigned int}; <template-parameter-2-2> = void; _Elements = {long unsigned int, long unsigned int, long unsigned int}]’
     triangles.push_back({si + 0, si + 1, si + 2});
                                                 ^
/home/valera/github.com/r0mai/3d-fractals/src/Model.cpp:23:49: error: converting to ‘std::vector<std::tuple<long unsigned int, long unsigned int, long unsigned int> >::value_type {aka std::tuple<long unsigned int, long unsigned int, long unsigned int>}’ from initializer list would use explicit constructor ‘constexpr std::tuple< <template-parameter-1-1> >::tuple(_UElements&& ...) [with _UElements = {long unsigned int, long unsigned int, long unsigned int}; <template-parameter-2-2> = void; _Elements = {long unsigned int, long unsigned int, long unsigned int}]’
     triangles.push_back({si + 0, si + 1, si + 3});
                                                 ^
/home/valera/github.com/r0mai/3d-fractals/src/Model.cpp:24:49: error: converting to ‘std::vector<std::tuple<long unsigned int, long unsigned int, long unsigned int> >::value_type {aka std::tuple<long unsigned int, long unsigned int, long unsigned int>}’ from initializer list would use explicit constructor ‘constexpr std::tuple< <template-parameter-1-1> >::tuple(_UElements&& ...) [with _UElements = {long unsigned int, long unsigned int, long unsigned int}; <template-parameter-2-2> = void; _Elements = {long unsigned int, long unsigned int, long unsigned int}]’
     triangles.push_back({si + 0, si + 2, si + 3});
                                                 ^
/home/valera/github.com/r0mai/3d-fractals/src/Model.cpp:25:49: error: converting to ‘std::vector<std::tuple<long unsigned int, long unsigned int, long unsigned int> >::value_type {aka std::tuple<long unsigned int, long unsigned int, long unsigned int>}’ from initializer list would use explicit constructor ‘constexpr std::tuple< <template-parameter-1-1> >::tuple(_UElements&& ...) [with _UElements = {long unsigned int, long unsigned int, long unsigned int}; <template-parameter-2-2> = void; _Elements = {long unsigned int, long unsigned int, long unsigned int}]’
     triangles.push_back({si + 1, si + 2, si + 3});
                                                 ^
src/CMakeFiles/srclib.dir/build.make:89: recipe for target 'src/CMakeFiles/srclib.dir/Model.cpp.o' failed
make[2]: *** [src/CMakeFiles/srclib.dir/Model.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
```
